### PR TITLE
Add Fees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a_block_chain"
-version = "0.1.0"
+version = "1.1.0"
 homepage = "https://a-block.io"
 description = "A-Block Chain is a distributed blockchain store with a dual double entry (DDE) data structure."
 authors = ["Byron Houwens <byron.houwens@gmail.com>", "Anton Troskie <troskie.a@gmail.com>"]

--- a/src/primitives/druid.rs
+++ b/src/primitives/druid.rs
@@ -21,6 +21,7 @@ pub struct DdeValues {
     pub druid: String,
     pub participants: usize,
     pub expectations: Vec<DruidExpectation>,
+    pub drs_tx_hash: Option<String>,
 }
 
 impl DdeValues {

--- a/src/primitives/transaction.rs
+++ b/src/primitives/transaction.rs
@@ -173,6 +173,7 @@ pub struct Transaction {
     pub inputs: Vec<TxIn>,
     pub outputs: Vec<TxOut>,
     pub version: usize,
+    pub fees: Vec<TxOut>,
     pub druid_info: Option<DdeValues>,
 }
 
@@ -188,6 +189,7 @@ impl Transaction {
         Transaction {
             inputs: Vec::new(),
             outputs: Vec::new(),
+            fees: Vec::new(),
             version: NETWORK_VERSION as usize,
             druid_info: None,
         }

--- a/src/utils/druid_utils.rs
+++ b/src/utils/druid_utils.rs
@@ -102,16 +102,26 @@ mod tests {
         ];
 
         // Txs
+        let alice_druid_info = DdeValues {
+            druid: druid.clone(),
+            participants: 2,
+            expectations: expects.clone(),
+            drs_tx_hash: None,
+        };
         let alice_tx = construct_dde_tx(
-            druid.clone(),
+            alice_druid_info,
             tx_input.clone(),
             vec![token_tx_out],
             None,
-            2,
-            expects.clone(),
         );
 
-        let bob_tx = construct_dde_tx(druid, tx_input, vec![data_tx_out], None, 2, expects);
+        let bob_druid_info = DdeValues {
+            druid: druid.clone(),
+            participants: 2,
+            expectations: expects.clone(),
+            drs_tx_hash: None,
+        };
+        let bob_tx = construct_dde_tx(bob_druid_info, tx_input, vec![data_tx_out], None);
 
         vec![alice_tx, bob_tx]
     }
@@ -148,15 +158,23 @@ mod tests {
                 asset: Asset::item(1, Some("drs_tx_hash".to_owned()), None),
             };
 
+            let druid_info = DdeValues {
+                druid: druid.clone(),
+                participants: 2,
+                expectations: vec![expectation.clone()],
+                drs_tx_hash: None,
+            };
+
             let mut tx = construct_rb_payments_send_tx(
                 tx_ins,
                 Vec::new(),
                 None,
-                bob_addr.clone(),
-                payment,
+                ReceiverInfo {
+                    address: bob_addr.clone(),
+                    asset: Asset::Token(payment),
+                },
                 0,
-                druid.clone(),
-                vec![expectation],
+                druid_info
             );
 
             tx.outputs.push(excess_tx_out);
@@ -176,6 +194,13 @@ mod tests {
                 asset: Asset::Token(payment),
             };
 
+            let druid_info = DdeValues {
+                druid: druid.clone(),
+                participants: 2,
+                expectations: vec![expectation.clone()],
+                drs_tx_hash: Some("drs_tx_hash".to_owned()),
+            };
+
             // create the sender that match the receiver.
             construct_rb_receive_payment_tx(
                 tx_ins,
@@ -183,9 +208,7 @@ mod tests {
                 None,
                 alice_addr,
                 0,
-                druid,
-                vec![expectation],
-                Some("drs_tx_hash".to_owned()),
+                druid_info
             )
         };
 
@@ -215,6 +238,7 @@ mod tests {
             druid: "VALUE".to_owned(),
             participants: 2,
             expectations: expects,
+            drs_tx_hash: None,
         };
         change_tx.druid_info = Some(nm_druid_info);
 

--- a/src/utils/druid_utils.rs
+++ b/src/utils/druid_utils.rs
@@ -108,12 +108,8 @@ mod tests {
             expectations: expects.clone(),
             drs_tx_hash: None,
         };
-        let alice_tx = construct_dde_tx(
-            alice_druid_info,
-            tx_input.clone(),
-            vec![token_tx_out],
-            None,
-        );
+        let alice_tx =
+            construct_dde_tx(alice_druid_info, tx_input.clone(), vec![token_tx_out], None);
 
         let bob_druid_info = DdeValues {
             druid: druid.clone(),
@@ -174,7 +170,7 @@ mod tests {
                     asset: Asset::Token(payment),
                 },
                 0,
-                druid_info
+                druid_info,
             );
 
             tx.outputs.push(excess_tx_out);
@@ -202,14 +198,7 @@ mod tests {
             };
 
             // create the sender that match the receiver.
-            construct_rb_receive_payment_tx(
-                tx_ins,
-                Vec::new(),
-                None,
-                alice_addr,
-                0,
-                druid_info
-            )
+            construct_rb_receive_payment_tx(tx_ins, Vec::new(), None, alice_addr, 0, druid_info)
         };
 
         (send_tx, recv_tx)

--- a/src/utils/druid_utils.rs
+++ b/src/utils/druid_utils.rs
@@ -106,11 +106,12 @@ mod tests {
             druid.clone(),
             tx_input.clone(),
             vec![token_tx_out],
+            None,
             2,
             expects.clone(),
         );
 
-        let bob_tx = construct_dde_tx(druid, tx_input, vec![data_tx_out], 2, expects);
+        let bob_tx = construct_dde_tx(druid, tx_input, vec![data_tx_out], None, 2, expects);
 
         vec![alice_tx, bob_tx]
     }
@@ -150,6 +151,7 @@ mod tests {
             let mut tx = construct_rb_payments_send_tx(
                 tx_ins,
                 Vec::new(),
+                None,
                 bob_addr.clone(),
                 payment,
                 0,
@@ -178,6 +180,7 @@ mod tests {
             construct_rb_receive_payment_tx(
                 tx_ins,
                 Vec::new(),
+                None,
                 alice_addr,
                 0,
                 druid,

--- a/src/utils/transaction_utils.rs
+++ b/src/utils/transaction_utils.rs
@@ -574,11 +574,7 @@ pub fn construct_rb_receive_payment_tx(
     druid_info: DdeValues
 ) -> Transaction {
     let out = TxOut {
-<<<<<<< HEAD
-        value: Asset::item(1, drs_tx_hash, None),
-=======
-        value: Asset::receipt(1, druid_info.drs_tx_hash, None),
->>>>>>> 8d3d744 (Manage fees within DDE transactions)
+        value: Asset::item(1, druid_info.drs_tx_hash, None),
         locktime,
         script_public_key: Some(sender_address),
         drs_block_hash: None, // this will need to change
@@ -662,11 +658,7 @@ pub fn construct_dde_tx(
 mod tests {
     use super::*;
     use crate::crypto::sign_ed25519::{self as sign, Signature};
-<<<<<<< HEAD
-    use crate::primitives::asset::{AssetValues, ItemAsset};
-=======
-    use crate::primitives::asset::{AssetValues, ReceiptAsset, TokenAmount};
->>>>>>> 8d3d744 (Manage fees within DDE transactions)
+    use crate::primitives::asset::{AssetValues, ItemAsset, TokenAmount};
     use crate::script::OpCodes;
     use crate::utils::script_utils::{tx_has_valid_p2sh_script, tx_outs_are_valid};
 


### PR DESCRIPTION
Adds a `fees`  attribute to the transaction structure, which will allow the transaction to specify transaction fee outputs from the inputs. The major changes in this MR include:

- Add `fees` to the `Transaction` struct (specified as a `Vec<TxOut>`)
- Update unit tests to use the new structure
- Update transaction creation utility functions to include fees as input
- Matching fees as part of the transaction outputs, when comparing against the available inputs