### PR TITLE
Add timestamp attribute to block header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a_block_chain"
-version = "1.1.0"
+version = "1.2.0"
 homepage = "https://a-block.io"
 description = "A-Block Chain is a distributed blockchain store with a dual double entry (DDE) data structure."
 authors = ["Byron Houwens <byron.houwens@gmail.com>", "Anton Troskie <troskie.a@gmail.com>"]

--- a/src/primitives/block.rs
+++ b/src/primitives/block.rs
@@ -22,6 +22,7 @@ pub struct BlockHeader {
     pub bits: usize,
     pub nonce_and_mining_tx_hash: (Vec<u8>, String),
     pub b_num: u64,
+    pub timestamp: String,
     pub seed_value: Vec<u8>, // for commercial
     pub previous_hash: Option<String>,
     pub txs_merkle_root_and_hash: (String, String),
@@ -41,6 +42,7 @@ impl BlockHeader {
             bits: 0,
             nonce_and_mining_tx_hash: Default::default(),
             b_num: 0,
+            timestamp: String::default(),
             seed_value: Vec::new(),
             previous_hash: None,
             txs_merkle_root_and_hash: Default::default(),


### PR DESCRIPTION
## Description
Just adds a `timestamp` attribute to the block header, which will be further implemented in the Network repo. There's no additional logic requirement from Chain.

## Type of Change
Please mark the appropriate option by putting an "x" inside the brackets:

- [ ] Bug fix
- [x] New feature
- [x] Enhancement or optimization
- [ ] Documentation update
- [ ] Other (please specify)

## Checklist
Put an "x" in the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added necessary documentation or updated existing documentation.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have added/updated relevant tests to ensure the changes are properly covered.
- [x] I have checked for and resolved any merge conflicts.
- [ ] My commits have clear and descriptive messages.